### PR TITLE
[US354064] Use init-tool

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -195,7 +195,7 @@ def main():
 
     if program_args.component:
         validate_components(program_args.component, component_paths)
-        deploy(program_args.component + ['data-entity'], component_paths, program_args)
+        deploy(program_args.component + ['data-entity', 'init'], component_paths, program_args)
         if program_args.init:
             initialise(component_paths, program_args)
 

--- a/docker-compose/docker-compose.init.yml
+++ b/docker-compose/docker-compose.init.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2021-2023 Open Text.
+#
+# Licensed under the MIT License (the "License"); you may not use this file
+# except in compliance with the License.
+#
+# The only warranties for products and services of Open Text and its affiliates
+# and licensors ("Open Text") are as may be set forth in the express warranty
+# statements accompanying such products and services. Nothing herein should be
+# construed as constituting an additional warranty. Open Text shall not be
+# liable for technical or editorial errors or omissions contained herein. The
+# information contained herein is subject to change without notice.
+#
+
+services:
+
+  init-tool:
+    image: ${ISOL_DOCKER_REGISTRY}${ISOL_DOCKER_NAME_SEP}solutions-init-tool${ISOL_DOCKER_VERSION_SEP}${ISOL_API_VERSION}
+    networks:
+      - main
+    volumes:
+      - entity-data:/data/entity
+    environment:
+      - ISOL_ENTITY_STORAGEDB_HOST=${ISOL_ENTITY_STORAGEDB_HOST}
+      - ISOL_ENTITY_STORAGEDB_PORT=${ISOL_ENTITY_STORAGEDB_PORT}
+      - ISOL_ENTITY_INDEXDB_HOST=${ISOL_ENTITY_INDEXDB_HOST}
+      - ISOL_ENTITY_INDEXDB_ACI_PORT=${ISOL_ENTITY_INDEXDB_ACI_PORT}
+      - ISOL_ENTITY_INDEXDB_INDEX_PORT=${ISOL_ENTITY_INDEXDB_INDEX_PORT}
+      - ISOL_ENTITY_DATA_VOLUME_PATH=/data/entity
+      - ISOL_ENTITY_GRAPH_NAME=entities
+
+volumes:
+  entity-data:

--- a/helm/lema/templates/configMap/auth-setup.yml
+++ b/helm/lema/templates/configMap/auth-setup.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.api.authSetup.config }}
+  name: {{ .Values.authSetup.config }}
 data:
   ISOL_AUTH_SERVICE_PROTOCOL: "{{ .Values.auth.service.protocol }}"
   ISOL_AUTH_SERVICE_HOST: "{{ .Values.auth.service.name }}"
@@ -19,7 +19,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.api.authSetup.secret }}
+  name: {{ .Values.authSetup.secret }}
 data:
   ISOL_AUTH_SERVICE_ADMIN_USER: "{{ .Values.auth.adminUser | b64enc }}"
   ISOL_AUTH_SERVICE_ADMIN_PASS: "{{ .Values.auth.adminPassword | b64enc }}"

--- a/helm/lema/templates/configMap/init-tool.yml
+++ b/helm/lema/templates/configMap/init-tool.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.initTool.config }}
+data:
+
+  ISOL_ENTITY_STORAGEDB_HOST: "{{ .Values.entity.storage.service.name }}"
+  ISOL_ENTITY_STORAGEDB_PORT: "{{ .Values.entity.storage.service.port }}"
+  ISOL_ENTITY_INDEXDB_HOST: "{{ .Values.entity.index.service.name }}"
+  ISOL_ENTITY_INDEXDB_ACI_PORT: "{{ .Values.entity.index.service.queryPort }}"
+  ISOL_ENTITY_INDEXDB_INDEX_PORT: "{{ .Values.entity.index.service.indexPort }}"
+  ISOL_ENTITY_DATA_VOLUME_PATH: "/data/entity"
+  ISOL_ENTITY_GRAPH_NAME: "{{ .Values.entity.graphName }}"

--- a/helm/lema/templates/deployment/api.yml
+++ b/helm/lema/templates/deployment/api.yml
@@ -14,34 +14,8 @@ spec:
       labels:
         component: {{ .Values.api.name }}
     spec:
-      initContainers:
-
-        - name: {{ .Values.api.dataEntity.container }}
-{{ include "image" (dict
-  "Values" .Values
-  "imageName" .Values.api.dataEntity.image
-  "version" .Values.docker.versions.lemaData
-  ) | indent 10 }}
-          imagePullPolicy: {{ .Values.docker.pullPolicy }}
-          volumeMounts:
-            - name: {{ .Values.api.dataVolume }}
-              mountPath: /target-volume
-
-        - name: {{ .Values.api.authSetup.container }}
-{{ include "image" (dict
-  "Values" .Values
-  "imageName" .Values.api.authSetup.image
-  "version" .Values.docker.versions.api
-  ) | indent 10 }}
-          imagePullPolicy: {{ .Values.docker.pullPolicy }}
-          envFrom:
-            - secretRef:
-                name: {{ .Values.api.authSetup.secret }}
-            - configMapRef:
-                name: {{ .Values.api.authSetup.config }}
-
       containers:
-        - name: api-service-container
+        - name: {{ .Values.api.container }}
 {{ include "image" (dict
   "Values" .Values
   "imageName" .Values.api.image

--- a/helm/lema/templates/hooks/post-install/auth-setup.yaml
+++ b/helm/lema/templates/hooks/post-install/auth-setup.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Values.authSetup.name }}"
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        component: {{ .Values.authSetup.name }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ .Values.authSetup.container }}
+{{ include "image" (dict
+  "Values" .Values
+  "imageName" .Values.authSetup.image
+  "version" .Values.docker.versions.api
+  ) | indent 10 }}
+          imagePullPolicy: {{ .Values.docker.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.authSetup.secret }}
+            - configMapRef:
+                name: {{ .Values.authSetup.config }}
+
+
+      imagePullSecrets:
+        - name: {{ .Values.secret.name }}

--- a/helm/lema/templates/hooks/post-install/copy-schema.yaml
+++ b/helm/lema/templates/hooks/post-install/copy-schema.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Values.dataEntity.name }}"
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        component: {{ .Values.dataEntity.name }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ .Values.dataEntity.container }}
+{{ include "image" (dict
+  "Values" .Values
+  "imageName" .Values.dataEntity.image
+  "version" .Values.docker.versions.lemaData
+  ) | indent 10 }}
+          imagePullPolicy: {{ .Values.docker.pullPolicy }}
+          volumeMounts:
+            - name: {{ .Values.api.dataVolume }}
+              mountPath: /target-volume
+
+      volumes:
+        - name: {{ .Values.api.dataVolume }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.api.dataVolumeClaim }}
+
+      imagePullSecrets:
+        - name: {{ .Values.secret.name }}

--- a/helm/lema/templates/hooks/post-install/initialize-schema.yaml
+++ b/helm/lema/templates/hooks/post-install/initialize-schema.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Values.initTool.name }}"
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        component: {{ .Values.initTool.name }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: "{{ .Values.initTool.container }}"
+{{ include "image" (dict
+  "Values" .Values
+  "imageName" .Values.initTool.image
+  "version" .Values.docker.versions.api
+  ) | indent 10 }}
+          imagePullPolicy: {{ .Values.docker.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.initTool.config }}
+          volumeMounts:
+            - name: {{ .Values.api.dataVolume }}
+              mountPath: /data/entity
+            - name: {{ .Values.api.filesConfig.volumeName }}
+              mountPath: /data/entity/02-custom.yaml
+              subPath: entitySchema
+              readOnly: true
+      volumes:
+        - name: {{ .Values.api.dataVolume }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.api.dataVolumeClaim }}
+        - name: {{ .Values.api.filesConfig.volumeName }}
+          configMap:
+            name: {{ .Values.api.filesConfig.configName }}
+
+      imagePullSecrets:
+        - name: {{ .Values.secret.name }}

--- a/helm/lema/values.dev.yaml
+++ b/helm/lema/values.dev.yaml
@@ -9,12 +9,12 @@ docker:
   nameSeparator: ":"
   versionSeparator: "-"
   versions:
-    base: 23.4.1-SNAPSHOT
-    api: 23.4.1-SNAPSHOT
-    datasets: 23.4.1-SNAPSHOT
-    analysis: 23.4.1-SNAPSHOT
-    lemaData: 23.4.1-SNAPSHOT
-    lema: 23.4.1-SNAPSHOT
+    base: 23.4.0-SNAPSHOT
+    api: 23.4.0-SNAPSHOT
+    datasets: 23.4.0-SNAPSHOT
+    analysis: 23.4.0-SNAPSHOT
+    lemaData: 23.4.0-SNAPSHOT
+    lema: 23.4.0-SNAPSHOT
 
 entity:
   storage:

--- a/helm/lema/values.dev.yaml
+++ b/helm/lema/values.dev.yaml
@@ -9,12 +9,12 @@ docker:
   nameSeparator: ":"
   versionSeparator: "-"
   versions:
-    base: 23.4.0-SNAPSHOT
-    api: 23.4.0-SNAPSHOT
-    datasets: 23.4.0-SNAPSHOT
-    analysis: 23.4.0-SNAPSHOT
-    lemaData: 23.4.0-SNAPSHOT
-    lema: 23.4.0-SNAPSHOT
+    base: 23.4.1-SNAPSHOT
+    api: 23.4.1-SNAPSHOT
+    datasets: 23.4.1-SNAPSHOT
+    analysis: 23.4.1-SNAPSHOT
+    lemaData: 23.4.1-SNAPSHOT
+    lema: 23.4.1-SNAPSHOT
 
 entity:
   storage:

--- a/helm/lema/values.yaml
+++ b/helm/lema/values.yaml
@@ -61,6 +61,7 @@ auth:
     dataVolumeSize: 1Gi
 
 entity:
+  graphName: entities
   storage:
     enabled: true
     name: entity-storage-db
@@ -201,15 +202,17 @@ api:
     configName: api-config-files
     volumeName: api-config-files
 
-  dataEntity:
-    container: data-entity
-    image: solutions-lema-data-entity
+dataEntity:
+  name: data-entity
+  container: data-entity
+  image: solutions-lema-data-entity
 
-  authSetup:
-    container: auth-setup
-    image: solutions-auth-setup
-    config: auth-setup-config
-    secret: auth-setup-secret
+authSetup:
+  name: auth-setup
+  container: auth-setup
+  image: solutions-auth-setup
+  config: auth-setup-config
+  secret: auth-setup-secret
 
 lemaUi:
   enabled: true
@@ -223,3 +226,9 @@ lemaUi:
     port: 80
   external:
     path: /lema/
+
+initTool:
+  name: init-tool
+  container: init-tool-container
+  image: solutions-init-tool
+  config: init-tool-config


### PR DESCRIPTION
Entity schema init has been moved to init-tool.
Update helm charts to run this once in a post-install hook, deploy.py can just run it after the entity-schemas have been copied.